### PR TITLE
Update logrotate command location

### DIFF
--- a/templates/unbound-logrotate.j2
+++ b/templates/unbound-logrotate.j2
@@ -9,10 +9,6 @@
     sharedscripts
     create 644
     postrotate
-{% if ansible_os_family == 'Alpine' %}
         /usr/sbin/unbound-control log_reopen
-{% else %}
-        /usr/local/sbin/unbound-control log_reopen
-{% endif %}
     endscript
 }


### PR DESCRIPTION
The unbound location appears to be have changed for Ubuntu. On our AWS unbound instances, the unbound logs are writing to `unbound.log.1`, instead of `unbound.log`. logrotate is setup to run the `log_reopen` command in the wrong directory. `/usr/local/sbin/unbound-control` doesn’t exist on the box but `/usr/sbin/unbound-control` does. It is `Ubuntu 14.04.5 LTS (GNU/Linux 4.4.0-1010-aws x86_64)`.